### PR TITLE
fix(release): remove invalid changesets ignore entries

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -19,9 +19,6 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@tachui/docs",
-    "@tachui/demos",
-    "@tachui/intro-app",
-    "@tachui/calculator-app"
+    "@tachui/docs"
   ]
 }


### PR DESCRIPTION
## Summary
- remove invalid package names from `.changeset/config.json` `ignore`
- keep only `@tachui/docs` (valid private workspace package)
- unblock `changesets/action` on `main` so release PR/publish can proceed

## Root Cause
Changesets validates `ignore` entries against workspace package names. The config referenced non-existent packages (`@tachui/demos`, `@tachui/intro-app`, `@tachui/calculator-app`), causing `pnpm changeset:version` to fail in the release workflow.

## Validation
- `pnpm changeset status`
- `pnpm ci:check-changesets`
- pre-push hooks passed (`pnpm -r type-check` and `pnpm test:ci`)

## Impact
No runtime/package code changes; release infrastructure hotfix only.
