### PR TITLE
fix(release): grant pull-request permission to changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       packages: write
       id-token: write
     steps:


### PR DESCRIPTION
## Summary
- add `pull-requests: write` to the `release` job permissions in `.github/workflows/release.yml`

## Why
`changesets/action` needs pull request write scope to create the release PR (`changeset-release/main` -> `main`). Without it, release fails with:

`Resource not accessible by integration`

## Validation
- workflow change only (no package/runtime code)
- local pre-push hooks passed (`pnpm -r type-check` and `pnpm test:ci`)
