### PR TITLE
fix(release): disable git hooks in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     name: Changesets Release
     runs-on: ubuntu-latest
+    env:
+      SKIP_SIMPLE_GIT_HOOKS: '1'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- disable simple git hooks in the `release` GitHub Actions job
- prevent release CI from running local git hook checks during publish/version steps

## Why
- release runs were looping through heavyweight hook commands inside CI and failing before publish completed
- CI should run explicit workflow checks, not local developer hooks

## Validation
- workflow-only change
