### PR TITLE
ci(workflows): reduce duplicate CI/release/docs runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 

--- a/.github/workflows/docs-api.yml
+++ b/.github/workflows/docs-api.yml
@@ -4,11 +4,10 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/**'
+      - 'packages/**/src/**'
+      - 'packages/**/README.md'
       - 'docs/**'
       - 'typedoc.json'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
       - '.github/workflows/docs-api.yml'
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     branches: [main]
+    paths:
+      - '.changeset/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- make `CI` PR-only by removing `push` trigger from `.github/workflows/ci.yml`
- add `push.paths` filter to `release.yml` so release jobs run only on release-relevant changes
- narrow `docs-api.yml` path triggers to source/docs-level updates

## Why
This removes redundant workflow executions across:
- PR update
- merge to main
- changeset release PR lifecycle

while preserving required validation where it matters.

## Expected behavior after merge
- Standard feature PRs: full CI on PR only
- Merge to main: release/docs run only when relevant files changed
- Changeset release PRs: avoid unnecessary docs/CI reruns from version/changelog-only churn

## Validation
- `pnpm ci:check-changesets`
- push pre-checks passed (`type-check`, `test:ci`, modifiers tree-shaking)
