### PR TITLE
fix(release): enforce patch bumps for issue 135

### DIFF
--- a/.changeset/nasty-socks-lie.md
+++ b/.changeset/nasty-socks-lie.md
@@ -1,6 +1,6 @@
 ---
-'@tachui/core': minor
-'@tachui/primitives': minor
+'@tachui/core': patch
+'@tachui/primitives': patch
 ---
 
 Add template SVG rendering mode to `Image` with secure inline SVG sanitization, reactive themed source updates, and accessibility parity for template-rendered images.


### PR DESCRIPTION
## Summary
Adjust release intent for issue 135 to patch-only version bumps.

### Change
- Updated `.changeset/nasty-socks-lie.md`:
  - `@tachui/core`: `minor` -> `patch`
  - `@tachui/primitives`: `minor` -> `patch`

This prevents the pending Changesets release PR from promoting packages to `0.9.0`/`1.0.0` due to a minor bump chain.

## Validation
- `pnpm ci:check-changesets`
- push hook ran full `type-check` + `test:ci`

## Notes
After this PR merges, re-run/sync the existing release PR (`changeset-release/main`) so it regenerates with patch-level versions.
