### PR TITLE
chore(changeset): correct navigation bump type from minor to patch

### DIFF
--- a/.changeset/navigation-search-splitview-features.md
+++ b/.changeset/navigation-search-splitview-features.md
@@ -1,5 +1,5 @@
 ---
-"@tachui/navigation": minor
+"@tachui/navigation": patch
 ---
 
 Add three-column NavigationSplitView, searchable/suggestions/scopes modifiers, and fix NavigationStack root rendering


### PR DESCRIPTION
Fixes the changeset introduced in #151 — the bump type should be `patch` not `minor`. This will cause the Changesets release PR (#152) to regenerate with `@tachui/navigation@0.8.20` instead of `0.9.0`.