### PR TITLE
fix(core): harden FontAsset SSR guards for prerender

### DIFF
--- a/.changeset/fair-spoons-approve.md
+++ b/.changeset/fair-spoons-approve.md
@@ -1,0 +1,14 @@
+---
+"@tachui/core": patch
+"@tachui/ssr": patch
+"@tachui/types": patch
+"@tachui/modifiers": patch
+---
+
+Fix SSR serialization recursion for component inputs that also expose `build()` by prioritizing component render dispatch and guarding against cyclic builder chains.
+
+Improve asset typing ergonomics by adding declaration-merging support for custom `Assets` keys via `CustomAssets`.
+
+Add `.compositingGroup()` modifier mapped to `isolation: isolate`, with non-colliding priority so isolation is applied before blend-mode modifiers.
+
+Make `FontAsset` loading SSR-safe by no-oping DOM-dependent load paths when `document`/`window` are unavailable (prevents eager Google font crashes during prerender).

--- a/packages/core/__tests__/assets/FontAsset.test.ts
+++ b/packages/core/__tests__/assets/FontAsset.test.ts
@@ -305,5 +305,78 @@ describe('FontAsset', () => {
 
       warnSpy.mockRestore()
     })
+
+    it('is SSR-safe for eager Google fonts when DOM is unavailable', async () => {
+      const originalDocument = (globalThis as any).document
+      const originalWindow = (globalThis as any).window
+
+      try {
+        delete (globalThis as any).document
+        delete (globalThis as any).window
+
+        expect(() =>
+          createGoogleFont(
+            'Nunito',
+            [200, 400, 700],
+            'bodyFont',
+            {
+              loading: 'eager',
+              fontDisplay: 'swap',
+            }
+          )
+        ).not.toThrow()
+      } finally {
+        ;(globalThis as any).document = originalDocument
+        ;(globalThis as any).window = originalWindow
+      }
+    })
+
+    it('does not start lazy DOM loading during resolve() in SSR context', () => {
+      const originalDocument = (globalThis as any).document
+      const originalWindow = (globalThis as any).window
+
+      try {
+        delete (globalThis as any).document
+        delete (globalThis as any).window
+
+        const font = new FontAsset('Inter', [], 'ssr-test', {
+          fontUrl: 'https://example.com/inter.woff2',
+          loading: 'lazy',
+        })
+
+        expect(() => font.resolve()).not.toThrow()
+        expect((font as any).loadPromise).toBeNull()
+      } finally {
+        ;(globalThis as any).document = originalDocument
+        ;(globalThis as any).window = originalWindow
+      }
+    })
+
+    it('no-ops load when document is unavailable but window exists', async () => {
+      const originalDocument = (globalThis as any).document
+      const originalWindow = (globalThis as any).window
+      const createElementSpy = vi.spyOn(global.document, 'createElement')
+
+      try {
+        ;(globalThis as any).window = {
+          ...originalWindow,
+          FontFace: global.FontFace,
+        }
+        delete (globalThis as any).document
+
+        const font = new FontAsset('Inter', [], 'ssr-doc-missing', {
+          fontUrl: 'https://example.com/inter.woff2',
+          loading: 'eager',
+        })
+
+        await font.load()
+        expect((font as any).loadPromise).toBeNull()
+        expect(createElementSpy).not.toHaveBeenCalled()
+      } finally {
+        createElementSpy.mockRestore()
+        ;(globalThis as any).document = originalDocument
+        ;(globalThis as any).window = originalWindow
+      }
+    })
   })
 })

--- a/packages/core/src/assets/FontAsset.ts
+++ b/packages/core/src/assets/FontAsset.ts
@@ -84,6 +84,14 @@ export class FontAsset extends Asset {
       return
     }
 
+    // SSR/Node: no-op when DOM globals are unavailable.
+    if (
+      typeof document === 'undefined' ||
+      typeof window === 'undefined'
+    ) {
+      return
+    }
+
     if (this.loadPromise) {
       return this.loadPromise
     }
@@ -185,6 +193,7 @@ export class FontAsset extends Asset {
    * Load a font file directly and create @font-face rule
    */
   private async loadFontFile(url: string): Promise<void> {
+    // Browser-only path. `load()` guards SSR/non-DOM contexts before calling here.
     const { fontFormat, fontDisplay, weightRange, widthRange } = this.options
 
     // Determine format string


### PR DESCRIPTION
## Summary
- guard `FontAsset.load()` in non-browser/SSR contexts by no-oping when either `document` or `window` is unavailable
- document the browser-only assumption inside `loadFontFile()` so future changes do not bypass SSR guards
- add regression tests for:
  - eager Google font loading in SSR (no DOM globals)
  - lazy `resolve()` in SSR (no DOM load side effects)
  - partial-global scenario (`window` present, `document` missing)

Closes #172

## Validation
- `pnpm -r type-check`
- `pnpm test:ci`
- `pnpm test:tools`
- `pnpm -F @tachui/modifiers verify:tree-shaking`
