### PR TITLE
fix(benchmarks): build @tachui/types before combined benchmark report

### DIFF
--- a/tools/benchmarks/core-benchmark.ts
+++ b/tools/benchmarks/core-benchmark.ts
@@ -11,6 +11,7 @@ const historyDir = path.resolve(repoRoot, 'benchmarks/history')
 const browserResultsDir = path.resolve(repoRoot, 'packages/core/benchmarks/results/browser')
 const registryPackageDir = path.resolve(repoRoot, 'packages/registry')
 const registryDistEntry = path.resolve(registryPackageDir, 'dist/index.js')
+const typesDistEntry = path.resolve(repoRoot, 'packages/types/dist/assets.js')
 
 type TachUIBenchmarkModule = typeof import('../../packages/core/benchmarks/index.ts')
 type TachUIBenchmarkRun = Awaited<ReturnType<TachUIBenchmarkModule['runTachUIBenchmarks']>>
@@ -66,6 +67,14 @@ async function runCommand(command: string, args: string[], cwd: string): Promise
 }
 
 async function ensureBenchmarkDependencies(): Promise<void> {
+  if (!(await fileExists(typesDistEntry))) {
+    console.log('📦 Building @tachui/types (required for benchmark runtime imports)…')
+    await runCommand('bun', ['run', '--filter', '@tachui/types', 'build'], repoRoot)
+    if (!(await fileExists(typesDistEntry))) {
+      throw new Error(`Failed to build @tachui/types – missing ${typesDistEntry}`)
+    }
+  }
+
   if (await fileExists(registryDistEntry)) {
     return
   }


### PR DESCRIPTION
## Problem

The nightly `benchmark-report` workflow has failed every morning. The "Generate combined benchmark summary" step fails with:

```
Cannot find module '.../node_modules/@tachui/types/dist/assets.js'
imported from packages/core/src/assets/types.ts
```

## Root cause

The workflow only runs `bun install --frozen-lockfile` and never builds `@tachui/types`. The combined report imports `@tachui/core` source directly via tsx; core re-exports `@tachui/types/assets`, which resolves to `packages/types/dist/assets.js` — a build artifact generated by `create-js-stubs.js` during the types build. On a clean CI checkout that file doesn't exist, so the run fails with `ERR_MODULE_NOT_FOUND`.

The benchmark script already auto-builds `@tachui/registry` on demand but not its sibling `@tachui/types` dependency.

## Fix

`ensureBenchmarkDependencies()` in `tools/benchmarks/core-benchmark.ts` now builds `@tachui/types` first if its dist is missing, mirroring the existing registry handling. Keeping it in the script (rather than the workflow YAML) also protects local/manual runs.

## Verification

Deleted `packages/types/dist` and `packages/registry/dist` (simulating a clean CI checkout) and ran `bun run benchmark:report` — it rebuilds both and completes successfully.